### PR TITLE
Add more datatype for dataset create, write and read

### DIFF
--- a/main.c
+++ b/main.c
@@ -36,7 +36,7 @@ int main() {
     int level = 1;
     z5CreateFloat32Dataset(arrayName, ndim, shape, chunks, cusezlib, level);
     z5WriteFloat32Subarray(arrayName, data1, ndim, chunks, offset);
-    z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset); 
+    z5ReadFloat32Subarray(arrayName, rdata, ndim, chunks, offset);
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)
             for (int k = 0; k<chunks[2]; k++) 
@@ -44,7 +44,7 @@ int main() {
         printf("data1 = %f\n",data1[i][0][0]);
     }
     z5WriteFloat32Subarray("test_c.z5", data2, ndim, chunks, offset2);
-    z5ReadFloatSubarray("test_c.z5", rdata, ndim, chunks, offset2); 
+    z5ReadFloat32Subarray("test_c.z5", rdata, ndim, chunks, offset2);
     printf("after read float\n");
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)

--- a/main.c
+++ b/main.c
@@ -35,7 +35,7 @@ int main() {
     int cusezlib = 1;
     int level = 1;
     z5CreateFloat32Dataset(arrayName, ndim, shape, chunks, cusezlib, level);
-    z5WriteFloatSubarray(arrayName, data1, ndim, chunks, offset);
+    z5WriteFloat32Subarray(arrayName, data1, ndim, chunks, offset);
     z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset); 
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)
@@ -43,7 +43,7 @@ int main() {
                 assert(data1[i][j][k] == rdata[i][j][k]); 
         printf("data1 = %f\n",data1[i][0][0]);
     }
-    z5WriteFloatSubarray("test_c.z5", data2, ndim, chunks, offset2);
+    z5WriteFloat32Subarray("test_c.z5", data2, ndim, chunks, offset2);
     z5ReadFloatSubarray("test_c.z5", rdata, ndim, chunks, offset2); 
     printf("after read float\n");
     for (int i = 0; i < chunks[0]; i++){

--- a/main.c
+++ b/main.c
@@ -34,7 +34,7 @@ int main() {
     char* arrayName = "test_c.z5";
     int cusezlib = 1;
     int level = 1;
-    z5CreateFloatDataset(arrayName, ndim, shape, chunks, cusezlib, level);
+    z5CreateFloat32Dataset(arrayName, ndim, shape, chunks, cusezlib, level);
     z5WriteFloatSubarray(arrayName, data1, ndim, chunks, offset);
     z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset); 
     for (int i = 0; i < chunks[0]; i++){

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -26,6 +26,8 @@ void my_create_dataset(char* arrayName)
     uint8_t rui8data[10][10][10];
     uint16_t ui16data[10][10][10];
     uint16_t rui16data[10][10][10];
+    uint32_t ui32data[10][10][10];
+    uint32_t rui32data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
@@ -39,6 +41,7 @@ void my_create_dataset(char* arrayName)
                 i32data[i][j][k]=rand()%1000+1;
                 ui8data[i][j][k]=rand()%1000+1;
                 ui16data[i][j][k]=rand()%1000+1;
+                ui32data[i][j][k]=rand()%1000+1;
             }
         }
     }
@@ -183,19 +186,19 @@ void my_create_dataset(char* arrayName)
                 assert(ui16data[i][j][k] == rui16data[i][j][k]);
     }
     printf("===successfully read UInt16Dataset===\n");
-//
-//    char* int32arrayName = "new_file/group1/int32variables";
-//    z5CreateInt32Dataset(int32arrayName, ndim, shape, chunks, cusezlib, level);
-//    printf("===successfully creat Int32Dataset===\n");
-//    z5WriteInt32Subarray(int32arrayName, i32data, ndim, chunks, offset);
-//    printf("===successfully write Int32Dataset===\n");
-//    z5ReadInt32Subarray(int32arrayName, ri32data, ndim, chunks, offset);
-//    for (int i = 0; i < chunks[0]; i++){
-//        for (int j = 0; j < chunks[1]; j++)
-//            for (int k = 0; k<chunks[2]; k++)
-//                assert(i32data[i][j][k] == ri32data[i][j][k]);
-//    }
-//    printf("===successfully read Int32Dataset===\n");
+
+    char* uint32arrayName = "new_file/group1/uint32variables";
+    z5CreateUInt32Dataset(uint32arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat UInt32Dataset===\n");
+    z5WriteUInt32Subarray(uint32arrayName, ui32data, ndim, chunks, offset);
+    printf("===successfully write UInt32Dataset===\n");
+    z5ReadUInt32Subarray(uint32arrayName, rui32data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(ui32data[i][j][k] == rui32data[i][j][k]);
+    }
+    printf("===successfully read UInt32Dataset===\n");
 
 }
 

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -22,12 +22,16 @@ void my_create_dataset(char* arrayName)
     int16_t ri16data[10][10][10];
     int32_t i32data[10][10][10];
     int32_t ri32data[10][10][10];
+    int64_t i64data[10][10][10];
+    int64_t ri64data[10][10][10];
     uint8_t ui8data[10][10][10];
     uint8_t rui8data[10][10][10];
     uint16_t ui16data[10][10][10];
     uint16_t rui16data[10][10][10];
     uint32_t ui32data[10][10][10];
     uint32_t rui32data[10][10][10];
+    uint64_t ui64data[10][10][10];
+    uint64_t rui64data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
@@ -39,9 +43,11 @@ void my_create_dataset(char* arrayName)
                 i8data[i][j][k]=rand()%1000+1;
                 i16data[i][j][k]=rand()%1000+1;
                 i32data[i][j][k]=rand()%1000+1;
+                i64data[i][j][k]=rand()%1000+1;
                 ui8data[i][j][k]=rand()%1000+1;
                 ui16data[i][j][k]=rand()%1000+1;
                 ui32data[i][j][k]=rand()%1000+1;
+                ui64data[i][j][k]=rand()%1000+1;
             }
         }
     }
@@ -199,6 +205,19 @@ void my_create_dataset(char* arrayName)
                 assert(ui32data[i][j][k] == rui32data[i][j][k]);
     }
     printf("===successfully read UInt32Dataset===\n");
+
+    char* uint64arrayName = "new_file/group1/uint64variables";
+    z5CreateUInt64Dataset(uint64arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat UInt64Dataset===\n");
+    z5WriteUInt64Subarray(uint64arrayName, ui64data, ndim, chunks, offset);
+    printf("===successfully write UInt64Dataset===\n");
+    z5ReadUInt64Subarray(uint64arrayName, rui64data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(ui64data[i][j][k] == rui64data[i][j][k]);
+    }
+    printf("===successfully read UInt64Dataset===\n");
 
 }
 

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -18,6 +18,8 @@ void my_create_dataset(char* arrayName)
     long long int irdata[10][10][10];
     int8_t i8data[10][10][10];
     int8_t ri8data[10][10][10];
+    int16_t i16data[10][10][10];
+    int16_t ri16data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
@@ -27,6 +29,7 @@ void my_create_dataset(char* arrayName)
                 data2[i][j][k]=rand()%1000+1;
                 idata2[i][j][k]=rand()%1000+1;
                 i8data[i][j][k]=rand()%1000+1;
+                i16data[i][j][k]=rand()%1000+1;
             }
         }
     }
@@ -106,6 +109,7 @@ void my_create_dataset(char* arrayName)
     }
     printf("===successfully read Float64Dataset===\n");
 
+
     char* int8arrayName = "new_file/group1/int8variables";
     z5CreateInt8Dataset(int8arrayName, ndim, shape, chunks, cusezlib, level);
     printf("===successfully creat Int8Dataset===\n");
@@ -118,6 +122,19 @@ void my_create_dataset(char* arrayName)
                 assert(i8data[i][j][k] == ri8data[i][j][k]);
     }
     printf("===successfully read Int8Dataset===\n");
+
+    char* int16arrayName = "new_file/group1/int16variables";
+    z5CreateInt16Dataset(int16arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat Int16Dataset===\n");
+    z5WriteInt16Subarray(int16arrayName, i16data, ndim, chunks, offset);
+    printf("===successfully write Int16Dataset===\n");
+    z5ReadInt16Subarray(int16arrayName, ri16data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(i16data[i][j][k] == ri16data[i][j][k]);
+    }
+    printf("===successfully read Int16Dataset===\n");
 
 }
 

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -11,6 +11,7 @@ void my_create_dataset(char* arrayName)
     float data1[10][10][10];
     float data2[10][10][10];
     float rdata[10][10][10];
+    double ddata[10][10][10];
     long long int idata1[10][10][10];
     long long int idata2[10][10][10];
     long long int irdata[10][10][10];
@@ -34,7 +35,9 @@ void my_create_dataset(char* arrayName)
     //char* arrayName = "test_c.z5";
     int cusezlib = 1;
     int level = 1;
-    z5CreateFloatDataset(arrayName, ndim, shape, chunks, cusezlib, level);
+    z5CreateFloat32Dataset(arrayName, ndim, shape, chunks, cusezlib, level);
+
+    
     z5WriteFloatSubarray(arrayName, data1, ndim, chunks, offset);
     z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset);
     for (int i = 0; i < chunks[0]; i++){
@@ -92,6 +95,12 @@ void my_create_dataset(char* arrayName)
     z5readAttributesWithKeys(arrayName, keysinput, 2); 
     
     printf("after assert\n");
+
+    printf("testing different array type\n");
+    char* float64arrayName = "new_file/group1/float64variables";
+    z5CreateFloat64Dataset(float64arrayName, ndim, shape, chunks, cusezlib, level);
+
+    z5WriteFloat64Subarray(float64arrayName, ddata, ndim, chunks, offset);
 }
 
 void test_create_file()

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -12,6 +12,7 @@ void my_create_dataset(char* arrayName)
     float data2[10][10][10];
     float rdata[10][10][10];
     double ddata[10][10][10];
+    double rddata[10][10][10];
     long long int idata1[10][10][10];
     long long int idata2[10][10][10];
     long long int irdata[10][10][10];
@@ -39,15 +40,15 @@ void my_create_dataset(char* arrayName)
 
     
     z5WriteFloat32Subarray(arrayName, data1, ndim, chunks, offset);
-    z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset);
+    z5ReadFloat32Subarray(arrayName, rdata, ndim, chunks, offset);
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)
             for (int k = 0; k<chunks[2]; k++)
                 assert(data1[i][j][k] == rdata[i][j][k]);
-        printf("data1 = %f\n",data1[i][0][0]);
+//        printf("data1 = %f\n",data1[i][0][0]);
     }
     z5WriteFloat32Subarray(arrayName, data2, ndim, chunks, offset2);
-    z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset2);
+    z5ReadFloat32Subarray(arrayName, rdata, ndim, chunks, offset2);
     printf("after read float\n");
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)
@@ -96,11 +97,20 @@ void my_create_dataset(char* arrayName)
     
     printf("after assert\n");
 
-    printf("testing different array type\n");
+    printf("testing different array types\n");
+
     char* float64arrayName = "new_file/group1/float64variables";
     z5CreateFloat64Dataset(float64arrayName, ndim, shape, chunks, cusezlib, level);
-
+    printf("===successfully creat Float64Dataset===\n");
     z5WriteFloat64Subarray(float64arrayName, ddata, ndim, chunks, offset);
+    printf("===successfully write Float64Dataset===\n");
+    z5ReadFloat64Subarray(float64arrayName, rddata, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(ddata[i][j][k] == rddata[i][j][k]);
+    }
+    printf("===successfully read Float64Dataset===\n");
 }
 
 void test_create_file()

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -16,36 +16,29 @@ void my_create_dataset(char* arrayName)
     long long int idata1[10][10][10];
     long long int idata2[10][10][10];
     long long int irdata[10][10][10];
+    int8_t i8data[10][10][10];
+    int8_t ri8data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
             for (int k = 0; k<chunks[2]; k++){
                 data1[i][j][k]=rand()%1000+1;
                 idata1[i][j][k]=rand()%1000+1;
-            }
-        }
-    }
-    for (int i = 0; i < chunks[0]; i++){
-        for (int j = 0; j < chunks[1]; j++){
-            for (int k = 0; k<chunks[2]; k++){
                 data2[i][j][k]=rand()%1000+1;
                 idata2[i][j][k]=rand()%1000+1;
+                i8data[i][j][k]=rand()%1000+1;
             }
         }
     }
-    //char* arrayName = "test_c.z5";
     int cusezlib = 1;
     int level = 1;
     z5CreateFloat32Dataset(arrayName, ndim, shape, chunks, cusezlib, level);
-
-    
     z5WriteFloat32Subarray(arrayName, data1, ndim, chunks, offset);
     z5ReadFloat32Subarray(arrayName, rdata, ndim, chunks, offset);
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)
             for (int k = 0; k<chunks[2]; k++)
                 assert(data1[i][j][k] == rdata[i][j][k]);
-//        printf("data1 = %f\n",data1[i][0][0]);
     }
     z5WriteFloat32Subarray(arrayName, data2, ndim, chunks, offset2);
     z5ReadFloat32Subarray(arrayName, rdata, ndim, chunks, offset2);
@@ -99,6 +92,7 @@ void my_create_dataset(char* arrayName)
 
     printf("testing different array types\n");
 
+
     char* float64arrayName = "new_file/group1/float64variables";
     z5CreateFloat64Dataset(float64arrayName, ndim, shape, chunks, cusezlib, level);
     printf("===successfully creat Float64Dataset===\n");
@@ -111,6 +105,20 @@ void my_create_dataset(char* arrayName)
                 assert(ddata[i][j][k] == rddata[i][j][k]);
     }
     printf("===successfully read Float64Dataset===\n");
+
+    char* int8arrayName = "new_file/group1/int8variables";
+    z5CreateInt8Dataset(int8arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat Int8Dataset===\n");
+    z5WriteInt8Subarray(int8arrayName, i8data, ndim, chunks, offset);
+    printf("===successfully write Int8Dataset===\n");
+    z5ReadInt8Subarray(int8arrayName, ri8data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(i8data[i][j][k] == ri8data[i][j][k]);
+    }
+    printf("===successfully read Int8Dataset===\n");
+
 }
 
 void test_create_file()

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -38,7 +38,7 @@ void my_create_dataset(char* arrayName)
     z5CreateFloat32Dataset(arrayName, ndim, shape, chunks, cusezlib, level);
 
     
-    z5WriteFloatSubarray(arrayName, data1, ndim, chunks, offset);
+    z5WriteFloat32Subarray(arrayName, data1, ndim, chunks, offset);
     z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset);
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++)
@@ -46,7 +46,7 @@ void my_create_dataset(char* arrayName)
                 assert(data1[i][j][k] == rdata[i][j][k]);
         printf("data1 = %f\n",data1[i][0][0]);
     }
-    z5WriteFloatSubarray(arrayName, data2, ndim, chunks, offset2);
+    z5WriteFloat32Subarray(arrayName, data2, ndim, chunks, offset2);
     z5ReadFloatSubarray(arrayName, rdata, ndim, chunks, offset2);
     printf("after read float\n");
     for (int i = 0; i < chunks[0]; i++){

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -20,6 +20,8 @@ void my_create_dataset(char* arrayName)
     int8_t ri8data[10][10][10];
     int16_t i16data[10][10][10];
     int16_t ri16data[10][10][10];
+    int32_t i32data[10][10][10];
+    int32_t ri32data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
@@ -30,6 +32,7 @@ void my_create_dataset(char* arrayName)
                 idata2[i][j][k]=rand()%1000+1;
                 i8data[i][j][k]=rand()%1000+1;
                 i16data[i][j][k]=rand()%1000+1;
+                i32data[10][10][10];
             }
         }
     }
@@ -135,6 +138,19 @@ void my_create_dataset(char* arrayName)
                 assert(i16data[i][j][k] == ri16data[i][j][k]);
     }
     printf("===successfully read Int16Dataset===\n");
+
+    char* int32arrayName = "new_file/group1/int32variables";
+    z5CreateInt32Dataset(int32arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat Int32Dataset===\n");
+    z5WriteInt32Subarray(int32arrayName, i32data, ndim, chunks, offset);
+    printf("===successfully write Int32Dataset===\n");
+    z5ReadInt32Subarray(int32arrayName, ri32data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(i32data[i][j][k] == ri32data[i][j][k]);
+    }
+    printf("===successfully read Int32Dataset===\n");
 
 }
 

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -22,6 +22,8 @@ void my_create_dataset(char* arrayName)
     int16_t ri16data[10][10][10];
     int32_t i32data[10][10][10];
     int32_t ri32data[10][10][10];
+    uint8_t ui8data[10][10][10];
+    uint8_t rui8data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
@@ -32,7 +34,8 @@ void my_create_dataset(char* arrayName)
                 idata2[i][j][k]=rand()%1000+1;
                 i8data[i][j][k]=rand()%1000+1;
                 i16data[i][j][k]=rand()%1000+1;
-                i32data[10][10][10];
+                i32data[i][j][k]=rand()%1000+1;
+                ui8data[i][j][k]=rand()%1000+1;
             }
         }
     }
@@ -151,6 +154,45 @@ void my_create_dataset(char* arrayName)
                 assert(i32data[i][j][k] == ri32data[i][j][k]);
     }
     printf("===successfully read Int32Dataset===\n");
+
+    char* uint8arrayName = "new_file/group1/uint8variables";
+    z5CreateUInt8Dataset(uint8arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat UInt8Dataset===\n");
+    z5WriteUInt8Subarray(uint8arrayName, ui8data, ndim, chunks, offset);
+    printf("===successfully write UInt8Dataset===\n");
+    z5ReadUInt8Subarray(uint8arrayName, rui8data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(ui8data[i][j][k] == rui8data[i][j][k]);
+    }
+    printf("===successfully read UInt8Dataset===\n");
+
+//    char* int16arrayName = "new_file/group1/int16variables";
+//    z5CreateInt16Dataset(int16arrayName, ndim, shape, chunks, cusezlib, level);
+//    printf("===successfully creat Int16Dataset===\n");
+//    z5WriteInt16Subarray(int16arrayName, i16data, ndim, chunks, offset);
+//    printf("===successfully write Int16Dataset===\n");
+//    z5ReadInt16Subarray(int16arrayName, ri16data, ndim, chunks, offset);
+//    for (int i = 0; i < chunks[0]; i++){
+//        for (int j = 0; j < chunks[1]; j++)
+//            for (int k = 0; k<chunks[2]; k++)
+//                assert(i16data[i][j][k] == ri16data[i][j][k]);
+//    }
+//    printf("===successfully read Int16Dataset===\n");
+//
+//    char* int32arrayName = "new_file/group1/int32variables";
+//    z5CreateInt32Dataset(int32arrayName, ndim, shape, chunks, cusezlib, level);
+//    printf("===successfully creat Int32Dataset===\n");
+//    z5WriteInt32Subarray(int32arrayName, i32data, ndim, chunks, offset);
+//    printf("===successfully write Int32Dataset===\n");
+//    z5ReadInt32Subarray(int32arrayName, ri32data, ndim, chunks, offset);
+//    for (int i = 0; i < chunks[0]; i++){
+//        for (int j = 0; j < chunks[1]; j++)
+//            for (int k = 0; k<chunks[2]; k++)
+//                assert(i32data[i][j][k] == ri32data[i][j][k]);
+//    }
+//    printf("===successfully read Int32Dataset===\n");
 
 }
 

--- a/test_attributes.c
+++ b/test_attributes.c
@@ -24,6 +24,8 @@ void my_create_dataset(char* arrayName)
     int32_t ri32data[10][10][10];
     uint8_t ui8data[10][10][10];
     uint8_t rui8data[10][10][10];
+    uint16_t ui16data[10][10][10];
+    uint16_t rui16data[10][10][10];
     unsigned int ndim = 3;
     for (int i = 0; i < chunks[0]; i++){
         for (int j = 0; j < chunks[1]; j++){
@@ -36,6 +38,7 @@ void my_create_dataset(char* arrayName)
                 i16data[i][j][k]=rand()%1000+1;
                 i32data[i][j][k]=rand()%1000+1;
                 ui8data[i][j][k]=rand()%1000+1;
+                ui16data[i][j][k]=rand()%1000+1;
             }
         }
     }
@@ -168,18 +171,18 @@ void my_create_dataset(char* arrayName)
     }
     printf("===successfully read UInt8Dataset===\n");
 
-//    char* int16arrayName = "new_file/group1/int16variables";
-//    z5CreateInt16Dataset(int16arrayName, ndim, shape, chunks, cusezlib, level);
-//    printf("===successfully creat Int16Dataset===\n");
-//    z5WriteInt16Subarray(int16arrayName, i16data, ndim, chunks, offset);
-//    printf("===successfully write Int16Dataset===\n");
-//    z5ReadInt16Subarray(int16arrayName, ri16data, ndim, chunks, offset);
-//    for (int i = 0; i < chunks[0]; i++){
-//        for (int j = 0; j < chunks[1]; j++)
-//            for (int k = 0; k<chunks[2]; k++)
-//                assert(i16data[i][j][k] == ri16data[i][j][k]);
-//    }
-//    printf("===successfully read Int16Dataset===\n");
+    char* uint16arrayName = "new_file/group1/uint16variables";
+    z5CreateUInt16Dataset(uint16arrayName, ndim, shape, chunks, cusezlib, level);
+    printf("===successfully creat UInt16Dataset===\n");
+    z5WriteUInt16Subarray(uint16arrayName, ui16data, ndim, chunks, offset);
+    printf("===successfully write UInt16Dataset===\n");
+    z5ReadUInt16Subarray(uint16arrayName, rui16data, ndim, chunks, offset);
+    for (int i = 0; i < chunks[0]; i++){
+        for (int j = 0; j < chunks[1]; j++)
+            for (int k = 0; k<chunks[2]; k++)
+                assert(ui16data[i][j][k] == rui16data[i][j][k]);
+    }
+    printf("===successfully read UInt16Dataset===\n");
 //
 //    char* int32arrayName = "new_file/group1/int32variables";
 //    z5CreateInt32Dataset(int32arrayName, ndim, shape, chunks, cusezlib, level);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -25,7 +25,7 @@ namespace z5 {
         handle::Group cGroup(path_s);
         createGroup(cGroup, asZarr);
     } 
-    void z5CreateFloatDataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+    void z5CreateFloat32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
         std::string path_s(path);
         std::vector<std::string> dtype({"float32"});
         std::vector<size_t> shape_v(shape, shape + ndim);
@@ -42,6 +42,25 @@ namespace z5 {
         handle_.createDir();
         writeMetadata(handle_, floatMeta);
 
+    }
+
+    void z5CreateFloat64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+        std::vector<std::string> dtype({"float64"});
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+    
+        DatasetMetadata floatMeta(types::Datatype::float64,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+          floatMeta.compressor = types::zlib;
+          floatMeta.compressionOptions["useZlib"] = true;
+          floatMeta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, floatMeta);
+    
     }
 
     void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
@@ -81,6 +100,17 @@ namespace z5 {
         multiarray::writeSubarray<float>(ds,adp_array,offset_v.begin());
     }
 
+    void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim); 
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        xt::xarray<double> adp_array=xt::adapt(array,size,xt::no_ownership(),shape_v);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        multiarray::writeSubarray<double>(ds,adp_array,offset_v.begin());
+    }
     void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
         std::string path_s(path);
         auto ds =openDataset(path_s);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -261,6 +261,54 @@ namespace z5 {
         multiarray::readSubarray<int16_t>(ds,adp_array,offset_v.begin());
     }
 
+    void z5CreateInt32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata int32Meta(types::Datatype::int32,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            int32Meta.compressor = types::zlib;
+            int32Meta.compressionOptions["useZlib"] = true;
+            int32Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, int32Meta);
+    }
+
+    void z5WriteInt32Subarray(char *path, int32_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<int32_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<int32_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadInt32Subarray(char *path, int32_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<int32_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<int32_t>(ds,adp_array,offset_v.begin());
+    }
+
     size_t z5GetFileSize(char *path){
         std::string path_s(path);
 	fs::ifstream file(path_s, std::ios::binary);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -453,6 +453,54 @@ namespace z5 {
         multiarray::readSubarray<uint32_t>(ds,adp_array,offset_v.begin());
     }
 
+    void z5CreateUInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata uint64Meta(types::Datatype::uint64,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            uint64Meta.compressor = types::zlib;
+            uint64Meta.compressionOptions["useZlib"] = true;
+            uint64Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, uint64Meta);
+    }
+
+    void z5WriteUInt64Subarray(char *path, uint64_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<uint64_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<uint64_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadUInt64Subarray(char *path, uint64_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<uint64_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<uint64_t>(ds,adp_array,offset_v.begin());
+    }
+
     size_t z5GetFileSize(char *path){
         std::string path_s(path);
 	fs::ifstream file(path_s, std::ios::binary);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -117,54 +117,6 @@ namespace z5 {
         multiarray::readSubarray<double>(ds,adp_array,offset_v.begin());
     }
 
-    void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
-        std::string path_s(path);
-
-        std::vector<size_t> shape_v(shape, shape + ndim);
-        std::vector<size_t> chunks_v(chunks, chunks + ndim);
-        bool asZarr = true;
-
-        DatasetMetadata int64Meta(types::Datatype::int64,shape_v,chunks_v,asZarr);
-        if (cuseZlib) {
-            int64Meta.compressor = types::zlib;
-            int64Meta.compressionOptions["useZlib"] = true;
-            int64Meta.compressionOptions["level"] = level;
-        }
-        handle::Dataset handle_(path_s);
-        handle_.createDir();
-        writeMetadata(handle_, int64Meta);
-    }
-
-    void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
-        std::string path_s(path);
-        auto ds =openDataset(path_s);
-        using vec_type = std::vector<long int>;
-        size_t size = 1;
-        std::vector<std::size_t> shape_v(shape,shape + ndim); 
-        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
-            size=size*(*i);
-        using shape_type = std::vector<vec_type::size_type>;
-        shape_type s(shape,shape+ndim);
-        std::vector<size_t> offset_v(offset,offset + ndim);
-        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
-        multiarray::writeSubarray<long int>(ds,adp_array,offset_v.begin());
-    }
-
-    void z5ReadInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
-        std::string path_s(path);
-        auto ds = openDataset(path_s);
-        using vec_type = std::vector<long int>;
-        size_t size = 1;
-        std::vector<std::size_t> shape_v(shape,shape + ndim); 
-        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
-            size*=(*i);
-        using shape_type = std::vector<vec_type::size_type>;
-        shape_type s(shape,shape+ndim);
-        std::vector<size_t> offset_v(offset,offset + ndim);
-        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
-        multiarray::readSubarray<long int>(ds,adp_array,offset_v.begin()); 
-    }
-
     void z5CreateInt8Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
         std::string path_s(path);
 
@@ -309,6 +261,53 @@ namespace z5 {
         multiarray::readSubarray<int32_t>(ds,adp_array,offset_v.begin());
     }
 
+    void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata int64Meta(types::Datatype::int64,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            int64Meta.compressor = types::zlib;
+            int64Meta.compressionOptions["useZlib"] = true;
+            int64Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, int64Meta);
+    }
+
+    void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<long int>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<long int>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<long int>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<long int>(ds,adp_array,offset_v.begin());
+    }
 
     void z5CreateUInt8Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
         std::string path_s(path);
@@ -404,6 +403,54 @@ namespace z5 {
         std::vector<size_t> offset_v(offset,offset + ndim);
         auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
         multiarray::readSubarray<uint16_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5CreateUInt32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata uint32Meta(types::Datatype::uint32,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            uint32Meta.compressor = types::zlib;
+            uint32Meta.compressionOptions["useZlib"] = true;
+            uint32Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, uint32Meta);
+    }
+
+    void z5WriteUInt32Subarray(char *path, uint32_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<uint32_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<uint32_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadUInt32Subarray(char *path, uint32_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<uint32_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<uint32_t>(ds,adp_array,offset_v.begin());
     }
 
     size_t z5GetFileSize(char *path){

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -309,6 +309,55 @@ namespace z5 {
         multiarray::readSubarray<int32_t>(ds,adp_array,offset_v.begin());
     }
 
+
+    void z5CreateUInt8Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata uint8Meta(types::Datatype::uint8,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            uint8Meta.compressor = types::zlib;
+            uint8Meta.compressionOptions["useZlib"] = true;
+            uint8Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, uint8Meta);
+    }
+
+    void z5WriteUInt8Subarray(char *path, uint8_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<uint8_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<uint8_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadUInt8Subarray(char *path, uint8_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<uint8_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<uint8_t>(ds,adp_array,offset_v.begin());
+    }
+
     size_t z5GetFileSize(char *path){
         std::string path_s(path);
 	fs::ifstream file(path_s, std::ios::binary);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -90,6 +90,18 @@ namespace z5 {
     
     }
 
+    void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        xt::xarray<double> adp_array=xt::adapt(array,size,xt::no_ownership(),shape_v);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        multiarray::writeSubarray<double>(ds,adp_array,offset_v.begin());
+    }
+
     void z5ReadFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset) {
         std::string path_s(path);
         auto ds = openDataset(path_s);
@@ -107,39 +119,20 @@ namespace z5 {
 
     void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
         std::string path_s(path);
-        std::vector<std::string> dtype({"long long int"});
 
         std::vector<size_t> shape_v(shape, shape + ndim);
         std::vector<size_t> chunks_v(chunks, chunks + ndim);
         bool asZarr = true;
- 
+
         DatasetMetadata int64Meta(types::Datatype::int64,shape_v,chunks_v,asZarr);
         if (cuseZlib) {
-          int64Meta.compressor = types::zlib;
-          int64Meta.compressionOptions["useZlib"] = true;
-          int64Meta.compressionOptions["level"] = level;
+            int64Meta.compressor = types::zlib;
+            int64Meta.compressionOptions["useZlib"] = true;
+            int64Meta.compressionOptions["level"] = level;
         }
         handle::Dataset handle_(path_s);
         handle_.createDir();
         writeMetadata(handle_, int64Meta);
-    long long int idata1;
-    int64_t data1;
-    long int data2;
-    //std::cout<<"int64 "<<typeid(data1).name()<<" "<<sizeof(int64_t)<<std::endl;
-    //std::cout<<"long int "<<typeid(data2).name()<<" "<<sizeof(long int)<<std::endl;
-    //std::cout<<"long long int "<<typeid(idata1).name()<<" "<<sizeof(long long int)<<std::endl;
-}
-
-    void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset) {
-        std::string path_s(path);
-        auto ds =openDataset(path_s);
-        size_t size = 1;
-        std::vector<std::size_t> shape_v(shape,shape + ndim); 
-        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
-            size=size*(*i);
-        xt::xarray<double> adp_array=xt::adapt(array,size,xt::no_ownership(),shape_v);
-        std::vector<size_t> offset_v(offset,offset + ndim);
-        multiarray::writeSubarray<double>(ds,adp_array,offset_v.begin());
     }
 
     void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
@@ -170,6 +163,54 @@ namespace z5 {
         std::vector<size_t> offset_v(offset,offset + ndim);
         auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
         multiarray::readSubarray<long int>(ds,adp_array,offset_v.begin()); 
+    }
+
+    void z5CreateInt8Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata int8Meta(types::Datatype::int8,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            int8Meta.compressor = types::zlib;
+            int8Meta.compressionOptions["useZlib"] = true;
+            int8Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, int8Meta);
+    }
+
+    void z5WriteInt8Subarray(char *path, int8_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<int8_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<int8_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadInt8Subarray(char *path, int8_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<int8_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<int8_t>(ds,adp_array,offset_v.begin());
     }
 
     size_t z5GetFileSize(char *path){

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -358,6 +358,54 @@ namespace z5 {
         multiarray::readSubarray<uint8_t>(ds,adp_array,offset_v.begin());
     }
 
+    void z5CreateUInt16Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata uint16Meta(types::Datatype::uint16,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            uint16Meta.compressor = types::zlib;
+            uint16Meta.compressionOptions["useZlib"] = true;
+            uint16Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, uint16Meta);
+    }
+
+    void z5WriteUInt16Subarray(char *path, uint16_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<uint16_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<uint16_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadUInt16Subarray(char *path, uint16_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<uint16_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<uint16_t>(ds,adp_array,offset_v.begin());
+    }
+
     size_t z5GetFileSize(char *path){
         std::string path_s(path);
 	fs::ifstream file(path_s, std::ios::binary);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -88,7 +88,7 @@ namespace z5 {
     //std::cout<<"long long int "<<typeid(idata1).name()<<" "<<sizeof(long long int)<<std::endl;
 }
 
-    void z5WriteFloatSubarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset) {
+    void z5WriteFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset) {
         std::string path_s(path);
         auto ds =openDataset(path_s);
         size_t size = 1;

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -213,6 +213,54 @@ namespace z5 {
         multiarray::readSubarray<int8_t>(ds,adp_array,offset_v.begin());
     }
 
+    void z5CreateInt16Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
+        std::string path_s(path);
+
+        std::vector<size_t> shape_v(shape, shape + ndim);
+        std::vector<size_t> chunks_v(chunks, chunks + ndim);
+        bool asZarr = true;
+
+        DatasetMetadata int16Meta(types::Datatype::int16,shape_v,chunks_v,asZarr);
+        if (cuseZlib) {
+            int16Meta.compressor = types::zlib;
+            int16Meta.compressionOptions["useZlib"] = true;
+            int16Meta.compressionOptions["level"] = level;
+        }
+        handle::Dataset handle_(path_s);
+        handle_.createDir();
+        writeMetadata(handle_, int16Meta);
+    }
+
+    void z5WriteInt16Subarray(char *path, int16_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        using vec_type = std::vector<int16_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::writeSubarray<int16_t>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadInt16Subarray(char *path, int16_t *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<int16_t>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<int16_t>(ds,adp_array,offset_v.begin());
+    }
+
     size_t z5GetFileSize(char *path){
         std::string path_s(path);
 	fs::ifstream file(path_s, std::ios::binary);

--- a/z5wrapper.cc
+++ b/z5wrapper.cc
@@ -44,6 +44,33 @@ namespace z5 {
 
     }
 
+    void z5WriteFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds =openDataset(path_s);
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size=size*(*i);
+        xt::xarray<float> adp_array=xt::adapt(array,size,xt::no_ownership(),shape_v);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        multiarray::writeSubarray<float>(ds,adp_array,offset_v.begin());
+    }
+
+    void z5ReadFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<float>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<float>(ds,adp_array,offset_v.begin());
+    }
+
     void z5CreateFloat64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
         std::string path_s(path);
         std::vector<std::string> dtype({"float64"});
@@ -61,6 +88,21 @@ namespace z5 {
         handle_.createDir();
         writeMetadata(handle_, floatMeta);
     
+    }
+
+    void z5ReadFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset) {
+        std::string path_s(path);
+        auto ds = openDataset(path_s);
+        using vec_type = std::vector<float>;
+        size_t size = 1;
+        std::vector<std::size_t> shape_v(shape,shape + ndim);
+        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
+            size*=(*i);
+        using shape_type = std::vector<vec_type::size_type>;
+        shape_type s(shape,shape+ndim);
+        std::vector<size_t> offset_v(offset,offset + ndim);
+        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
+        multiarray::readSubarray<double>(ds,adp_array,offset_v.begin());
     }
 
     void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level) {
@@ -88,18 +130,6 @@ namespace z5 {
     //std::cout<<"long long int "<<typeid(idata1).name()<<" "<<sizeof(long long int)<<std::endl;
 }
 
-    void z5WriteFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset) {
-        std::string path_s(path);
-        auto ds =openDataset(path_s);
-        size_t size = 1;
-        std::vector<std::size_t> shape_v(shape,shape + ndim); 
-        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
-            size=size*(*i);
-        xt::xarray<float> adp_array=xt::adapt(array,size,xt::no_ownership(),shape_v);
-        std::vector<size_t> offset_v(offset,offset + ndim);
-        multiarray::writeSubarray<float>(ds,adp_array,offset_v.begin());
-    }
-
     void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset) {
         std::string path_s(path);
         auto ds =openDataset(path_s);
@@ -111,6 +141,7 @@ namespace z5 {
         std::vector<size_t> offset_v(offset,offset + ndim);
         multiarray::writeSubarray<double>(ds,adp_array,offset_v.begin());
     }
+
     void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
         std::string path_s(path);
         auto ds =openDataset(path_s);
@@ -126,20 +157,6 @@ namespace z5 {
         multiarray::writeSubarray<long int>(ds,adp_array,offset_v.begin());
     }
 
-    void z5ReadFloatSubarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset) {
-        std::string path_s(path);
-        auto ds = openDataset(path_s);
-        using vec_type = std::vector<float>;
-        size_t size = 1;
-        std::vector<std::size_t> shape_v(shape,shape + ndim); 
-        for (std::vector<size_t>::const_iterator i = shape_v.begin(); i != shape_v.end(); ++i)
-            size*=(*i);
-        using shape_type = std::vector<vec_type::size_type>;
-        shape_type s(shape,shape+ndim);
-        std::vector<size_t> offset_v(offset,offset + ndim);
-        auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
-        multiarray::readSubarray<float>(ds,adp_array,offset_v.begin()); 
-    }
     void z5ReadInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset) {
         std::string path_s(path);
         auto ds = openDataset(path_s);
@@ -154,6 +171,7 @@ namespace z5 {
         auto adp_array=xt::adapt(array,size,xt::no_ownership(),s);
         multiarray::readSubarray<long int>(ds,adp_array,offset_v.begin()); 
     }
+
     size_t z5GetFileSize(char *path){
         std::string path_s(path);
 	fs::ifstream file(path_s, std::ios::binary);

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -36,6 +36,11 @@ namespace z5 {
         void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset);
         void z5ReadFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset);
 
+        // int8_t
+        void z5CreateInt8Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteInt8Subarray(char *path, int8_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadInt8Subarray(char *path, int8_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+
         // int64
         void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
         void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -30,7 +30,7 @@ namespace z5 {
 
         void z5CreateFloat64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
 
-        void z5WriteFloatSubarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5WriteFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
 
         void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset);
 

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -26,20 +26,19 @@ namespace z5 {
 	
         void z5CreateGroup(char* path);
 
+        // float 32
         void z5CreateFloat32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
-
-        void z5CreateFloat64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
-
         void z5WriteFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadFloat32Subarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
 
+        // float 64 / double
+        void z5CreateFloat64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
         void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset);
 
-        void z5ReadFloatSubarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
-
+        // int64
         void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
-
         void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);
-
         void z5ReadInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);
 
         size_t z5GetFileSize(char *path);

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -41,6 +41,11 @@ namespace z5 {
         void z5WriteInt8Subarray(char *path, int8_t *array, unsigned int ndim, size_t *shape, size_t *offset);
         void z5ReadInt8Subarray(char *path, int8_t *array, unsigned int ndim, size_t *shape, size_t *offset);
 
+        // int16_t
+        void z5CreateInt16Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteInt16Subarray(char *path, int16_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadInt16Subarray(char *path, int16_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+
         // int64
         void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
         void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -18,6 +18,8 @@
 #include "z5/types/types.hxx"
 #endif
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 namespace z5 {
     extern "C" {
@@ -55,6 +57,26 @@ namespace z5 {
         void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
         void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);
         void z5ReadInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);
+
+        // uint8_t
+        void z5CreateUInt8Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteUInt8Subarray(char *path, uint8_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadUInt8Subarray(char *path, uint8_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+
+        // uint16_t
+        void z5CreateUInt16Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteUInt16Subarray(char *path, uint16_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadUInt16Subarray(char *path, uint16_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+
+        // uint32_t
+        void z5CreateUInt32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteUInt32Subarray(char *path, uint32_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadUInt32Subarray(char *path, uint32_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+
+        // uint64
+        void z5CreateUInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteUInt64Subarray(char *path, uint64_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadUInt64Subarray(char *path, uint64_t *array, unsigned int ndim, size_t *shape, size_t *offset);
 
         size_t z5GetFileSize(char *path);
 

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -26,9 +26,13 @@ namespace z5 {
 	
         void z5CreateGroup(char* path);
 
-        void z5CreateFloatDataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5CreateFloat32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+
+        void z5CreateFloat64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
 
         void z5WriteFloatSubarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
+
+        void z5WriteFloat64Subarray(char *path, double *array, unsigned int ndim, size_t *shape, size_t *offset);
 
         void z5ReadFloatSubarray(char *path, float *array, unsigned int ndim, size_t *shape, size_t *offset);
 

--- a/z5wrapper.h
+++ b/z5wrapper.h
@@ -46,6 +46,11 @@ namespace z5 {
         void z5WriteInt16Subarray(char *path, int16_t *array, unsigned int ndim, size_t *shape, size_t *offset);
         void z5ReadInt16Subarray(char *path, int16_t *array, unsigned int ndim, size_t *shape, size_t *offset);
 
+        // int32_t
+        void z5CreateInt32Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
+        void z5WriteInt32Subarray(char *path, int32_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+        void z5ReadInt32Subarray(char *path, int32_t *array, unsigned int ndim, size_t *shape, size_t *offset);
+
         // int64
         void z5CreateInt64Dataset(char *path, unsigned int ndim, size_t *shape, size_t *chunks, int cuseZlib, int level);
         void z5WriteInt64Subarray(char *path, long long int *array, unsigned int ndim, size_t *shape, size_t *offset);


### PR DESCRIPTION
1) This PR provides the following datatypes for creating, writing and reading dataset
- int8, int16, int32, uint8, uint16, uint32, uint64, float, double
2) and these added datatypes and the corresponding functionalities are fully tested.